### PR TITLE
Set the encoding of the gexf File

### DIFF
--- a/simplegexf.py
+++ b/simplegexf.py
@@ -64,7 +64,7 @@ class Gexf(BaseElement):
         self.path = os.path.realpath(path)
 
         try:
-            xml = open(self.path, 'r').read()
+            xml = open(self.path, 'r', encoding='utf-8').read()
         except IOError:
             xml = TEMPLATE
 
@@ -81,7 +81,7 @@ class Gexf(BaseElement):
         self.tree['gexf'] = value
 
     def write(self):
-        open(self.path, 'w+').write(str(self))
+        open(self.path, 'w+', encoding='utf-8').write(str(self))
 
     @property
     def _graphs(self):


### PR DESCRIPTION
Hello,

first of i'm not an expert in Python or Encoding. But i worked with you module and had some Issues with the encoding of the File. I fixed it for me by adding `encoding='utf-8'` to the Python open() Section.

I think it should be added to the Module since it is the [default encoding of the gexf files](https://gephi.org/gexf/format/dynamics.html).

Kind regards,
Philip Gisella