### PR TITLE
fix bug: get the edge attribute value with one edge attriute

### DIFF
--- a/simplegexf.py
+++ b/simplegexf.py
@@ -312,7 +312,10 @@ class NodeAttributes(MutableMapping):
 
     @property
     def _attvalues(self):
-        return self.obj.data['attvalues']['attvalue']
+        _attvalue = self.obj.data['attvalues']['attvalue']
+        if type(_attvalue).__name__ != 'list':
+            _attvalue = [_attvalue]
+        return _attvalue
 
     @property
     def _mapped_attvalues(self):


### PR DESCRIPTION
When the gexf has only one attribute, it cannont get the edge attribute value by the following form 

> edge.attributes["weight"]

The errors are:
`File "/opt/anaconda3/lib/python3.6/site-packages/simplegexf.py", line 335, in <dictcomp>
    return {int(v['@for']): v for v in self._attvalues}
TypeError: string indices must be integers`

Then I find that the `self.obj.data['attvalues']['attvalue']` just returns one `OrderedDict` result, if it defines one attribute. However here in `_mapped_attvalues` function needs one list of OrderedDict.

 
